### PR TITLE
#12: save comparison (structural diff + Compare Saves UI)

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,1065 @@
+//! Structural comparison of two Terra Invicta save games.
+//!
+//! Saves are large (tens of MB, thousands of objects), so the diff does not
+//! walk the two JSON trees positionally. Every gamestate object carries a
+//! stable integer ID (`Key.value`); objects are aligned by `(group, id)` and
+//! only the pairs that actually differ are walked field-by-field. Because
+//! [`TiValue`] derives `PartialEq`, an unchanged object costs exactly one
+//! whole-subtree compare and produces nothing, which is what keeps a 10k-object
+//! save tractable.
+//!
+//! The core is intentionally UI-free so it can be unit-tested headlessly and
+//! reused as a library self-test (prove that an edit perturbs *only* the
+//! intended field).
+
+use crate::save::LoadedSave;
+use crate::value::TiValue;
+use std::collections::BTreeSet;
+
+/// Whether an object was added, removed, or changed between two saves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffKind {
+    /// Present in the "after" save, absent in "before".
+    Added,
+    /// Present in the "before" save, absent in "after".
+    Removed,
+    /// Present in both with differing `Value` subtrees.
+    Changed,
+}
+
+/// A single leaf/subtree change inside a matched object, addressed by a
+/// dotted/bracketed JSON path relative to the object's `Value`
+/// (e.g. `resources.money`, `historyGDP[3]`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct FieldChange {
+    pub path: String,
+    /// `None` when the field only exists in the "after" save (added).
+    pub before: Option<TiValue>,
+    /// `None` when the field only exists in the "before" save (removed).
+    pub after: Option<TiValue>,
+}
+
+/// One object-level delta between two saves.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObjectDiff {
+    pub group: String,
+    pub id: i64,
+    pub display_name: String,
+    pub kind: DiffKind,
+    /// Field-level changes for `Changed` objects; empty for `Added`/`Removed`.
+    pub field_changes: Vec<FieldChange>,
+}
+
+/// The full result of comparing two saves.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SaveDiff {
+    /// Groups present only in the "after" save.
+    pub groups_added: Vec<String>,
+    /// Groups present only in the "before" save.
+    pub groups_removed: Vec<String>,
+    /// All object-level deltas, in a stable order (by group then id).
+    pub objects: Vec<ObjectDiff>,
+}
+
+impl SaveDiff {
+    pub fn is_empty(&self) -> bool {
+        self.groups_added.is_empty() && self.groups_removed.is_empty() && self.objects.is_empty()
+    }
+
+    pub fn count_kind(&self, kind: DiffKind) -> usize {
+        self.objects.iter().filter(|o| o.kind == kind).count()
+    }
+
+    /// Return `(added, removed, changed)` object counts in one pass.
+    pub fn summary_counts(&self) -> (usize, usize, usize) {
+        let mut counts = (0, 0, 0);
+        for o in &self.objects {
+            match o.kind {
+                DiffKind::Added => counts.0 += 1,
+                DiffKind::Removed => counts.1 += 1,
+                DiffKind::Changed => counts.2 += 1,
+            }
+        }
+        counts
+    }
+
+    /// Non-destructively re-filter a previously computed full diff by `ignore`,
+    /// returning a new `SaveDiff`. This is the cheap path the UI uses when the
+    /// user toggles an ignore checkbox: compute the full diff once (the
+    /// expensive tree walk), then re-derive the filtered view from the cached
+    /// result without touching the save files again.
+    ///
+    /// Semantics match `diff_saves` with the same rules applied up front:
+    /// - objects in an ignored group/id are dropped entirely;
+    /// - for `Changed` objects, field changes on ignored paths are removed, and
+    ///   if none survive the object itself is dropped;
+    /// - `Added`/`Removed` objects carry no field changes, so they survive any
+    ///   path-only ignore and are only removed by a group/id ignore.
+    pub fn filtered(&self, ignore: &IgnoreRules) -> SaveDiff {
+        let groups_added = self
+            .groups_added
+            .iter()
+            .filter(|g| !ignore.skips_object(g, i64::MIN))
+            .cloned()
+            .collect();
+        let groups_removed = self
+            .groups_removed
+            .iter()
+            .filter(|g| !ignore.skips_object(g, i64::MIN))
+            .cloned()
+            .collect();
+
+        let mut objects = Vec::new();
+        for obj in &self.objects {
+            if ignore.skips_object(&obj.group, obj.id) {
+                continue;
+            }
+            match obj.kind {
+                DiffKind::Added | DiffKind::Removed => objects.push(obj.clone()),
+                DiffKind::Changed => {
+                    let field_changes: Vec<FieldChange> = obj
+                        .field_changes
+                        .iter()
+                        .filter(|c| !ignore.skips_path(&c.path))
+                        .cloned()
+                        .collect();
+                    if field_changes.is_empty() {
+                        continue;
+                    }
+                    objects.push(ObjectDiff {
+                        field_changes,
+                        ..obj.clone()
+                    });
+                }
+            }
+        }
+
+        SaveDiff {
+            groups_added,
+            groups_removed,
+            objects,
+        }
+    }
+
+    /// All groups represented by object-level diffs, sorted for deterministic
+    /// UI filter lists.
+    pub fn changed_groups(&self) -> Vec<String> {
+        self.objects
+            .iter()
+            .map(|o| o.group.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    /// Non-destructively derive the Compare window's visible subset after the
+    /// expensive full diff has already been computed and any noise ignore rules
+    /// have already been applied.
+    ///
+    /// `visible_groups == None` means show every group. `Some(empty_set)` means
+    /// show nothing, which powers the UI's "ignore all, then check what I want"
+    /// flow. `query` is case-insensitive and matches object metadata (group, id,
+    /// display name, kind) or field details (path, before value, after value).
+    /// If object metadata matches, all of that object's surviving field changes
+    /// remain visible; if only individual fields match, the object remains with
+    /// just those matching fields.
+    pub fn view_filtered(
+        &self,
+        visible_groups: Option<&BTreeSet<String>>,
+        query: &str,
+    ) -> SaveDiff {
+        let query = query.trim().to_ascii_lowercase();
+        let group_allowed =
+            |group: &String| visible_groups.is_none_or(|groups| groups.contains(group));
+        let group_matches = |group: &String| query.is_empty() || contains_query(group, &query);
+
+        let groups_added = self
+            .groups_added
+            .iter()
+            .filter(|g| group_allowed(g) && group_matches(g))
+            .cloned()
+            .collect();
+        let groups_removed = self
+            .groups_removed
+            .iter()
+            .filter(|g| group_allowed(g) && group_matches(g))
+            .cloned()
+            .collect();
+
+        let mut objects = Vec::new();
+        for obj in &self.objects {
+            if !group_allowed(&obj.group) {
+                continue;
+            }
+            if query.is_empty() || object_metadata_matches_query(obj, &query) {
+                objects.push(obj.clone());
+                continue;
+            }
+            if obj.kind != DiffKind::Changed {
+                continue;
+            }
+            let field_changes: Vec<FieldChange> = obj
+                .field_changes
+                .iter()
+                .filter(|c| field_change_matches_query(c, &query))
+                .cloned()
+                .collect();
+            if !field_changes.is_empty() {
+                objects.push(ObjectDiff {
+                    field_changes,
+                    ..obj.clone()
+                });
+            }
+        }
+
+        SaveDiff {
+            groups_added,
+            groups_removed,
+            objects,
+        }
+    }
+}
+
+fn object_metadata_matches_query(obj: &ObjectDiff, query: &str) -> bool {
+    contains_query(&obj.group, query)
+        || contains_query(&obj.id.to_string(), query)
+        || contains_query(&obj.display_name, query)
+        || contains_query(
+            match obj.kind {
+                DiffKind::Added => "added",
+                DiffKind::Removed => "removed",
+                DiffKind::Changed => "changed",
+            },
+            query,
+        )
+}
+
+fn field_change_matches_query(change: &FieldChange, query: &str) -> bool {
+    contains_query(&change.path, query)
+        || change
+            .before
+            .as_ref()
+            .is_some_and(|v| contains_query(&v.to_json5_compact(), query))
+        || change
+            .after
+            .as_ref()
+            .is_some_and(|v| contains_query(&v.to_json5_compact(), query))
+}
+
+fn contains_query(haystack: &str, query: &str) -> bool {
+    haystack.to_ascii_lowercase().contains(query)
+}
+
+/// Predicate-driven filter that suppresses noise from the diff. The UI builds
+/// one of these from checkboxes; the diff core never knows the UI exists.
+///
+/// A field path matches an ignore prefix when it equals the prefix or begins
+/// with `prefix` followed by `.` or `[` (so `historyGDP` ignores
+/// `historyGDP[3]` but not `historyGDProjection`).
+#[derive(Debug, Clone, Default)]
+pub struct IgnoreRules {
+    groups: Vec<String>,
+    ids: Vec<i64>,
+    path_prefixes: Vec<String>,
+    /// First-segment name prefixes: a field is suppressed when the first
+    /// segment of its path *starts with* one of these (e.g. `history` catches
+    /// `historyGDP`, `historyWarStatus`, and any future `history*` series).
+    field_namespaces: Vec<String>,
+}
+
+impl IgnoreRules {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Default preset suppressing the per-turn time-series and event-log churn
+    /// that dominates a raw diff but carries no editing-relevant signal.
+    /// Calibrated against two real continuing saves (history* arrays and the
+    /// notification queue accounted for the overwhelming majority of changes).
+    pub fn default_noise_preset() -> Self {
+        Self::new()
+            // Every `history*` field is a per-turn time series appended each
+            // game tick. Match the whole namespace by first-segment prefix so
+            // uncalibrated series (e.g. `historyWarStatus`, only present when a
+            // nation is at war) are suppressed too, not just the ones observed
+            // during calibration.
+            .ignore_field_namespace("history")
+            // Rolling event/notification log.
+            .ignore_path_prefix("notificationSummaryQueue")
+    }
+
+    pub fn ignore_group(mut self, group: impl Into<String>) -> Self {
+        self.groups.push(group.into());
+        self
+    }
+
+    pub fn ignore_id(mut self, id: i64) -> Self {
+        self.ids.push(id);
+        self
+    }
+
+    pub fn ignore_path_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.path_prefixes.push(prefix.into());
+        self
+    }
+
+    /// Suppress an entire field namespace: any field whose first path segment
+    /// *starts with* `name` is dropped. Unlike `ignore_path_prefix` (which is
+    /// an exact-segment match), this catches a whole family of related fields,
+    /// e.g. `ignore_field_namespace("history")` suppresses `historyGDP`,
+    /// `historyWarStatus`, and any other `history*` series without enumerating
+    /// each one.
+    pub fn ignore_field_namespace(mut self, name: impl Into<String>) -> Self {
+        self.field_namespaces.push(name.into());
+        self
+    }
+
+    /// True when an entire object (by group or id) should be skipped.
+    pub fn skips_object(&self, group: &str, id: i64) -> bool {
+        self.groups.iter().any(|g| g == group) || self.ids.contains(&id)
+    }
+
+    /// True when a field path (relative to the object's `Value`) is suppressed.
+    pub fn skips_path(&self, path: &str) -> bool {
+        self.path_prefixes
+            .iter()
+            .any(|prefix| path_has_prefix(path, prefix))
+            || self
+                .field_namespaces
+                .iter()
+                .any(|name| first_segment(path).starts_with(name.as_str()))
+    }
+}
+
+/// The first path segment: everything up to the first `.` or `[`. For
+/// `historyWarStatus[19]` this is `historyWarStatus`; for `publicOpinion.Resist`
+/// it is `publicOpinion`.
+fn first_segment(path: &str) -> &str {
+    let end = path.find(['.', '[']).unwrap_or(path.len());
+    &path[..end]
+}
+
+/// Match `path` against a segment-aware `prefix`: equal, or `prefix` followed
+/// by a `.` (nested key) or `[` (array index).
+fn path_has_prefix(path: &str, prefix: &str) -> bool {
+    if !path.starts_with(prefix) {
+        return false;
+    }
+    matches!(
+        path.as_bytes().get(prefix.len()),
+        None | Some(b'.') | Some(b'[')
+    )
+}
+
+/// Compare two loaded saves, aligning objects by `(group, id)` and walking only
+/// the pairs whose `Value` subtrees differ. `ignore` suppresses noisy
+/// groups/ids/field-paths.
+pub fn diff_saves(before: &LoadedSave, after: &LoadedSave, ignore: &IgnoreRules) -> SaveDiff {
+    use std::collections::BTreeSet;
+
+    let mut diff = SaveDiff::default();
+
+    let before_groups: BTreeSet<&String> = before.index.groups.iter().collect();
+    let after_groups: BTreeSet<&String> = after.index.groups.iter().collect();
+
+    for g in after_groups.difference(&before_groups) {
+        if !ignore.skips_object(g, i64::MIN) {
+            diff.groups_added.push((*g).clone());
+        }
+    }
+    for g in before_groups.difference(&after_groups) {
+        if !ignore.skips_object(g, i64::MIN) {
+            diff.groups_removed.push((*g).clone());
+        }
+    }
+
+    // Object-level alignment by (group, id) across every group in either save.
+    let all_groups: BTreeSet<&String> = before_groups.union(&after_groups).copied().collect();
+
+    for group in all_groups {
+        let before_objs = before.index.objects_by_group.get(group);
+        let after_objs = after.index.objects_by_group.get(group);
+
+        let before_ids: BTreeSet<i64> = before_objs
+            .map(|v| v.iter().map(|o| o.id).collect())
+            .unwrap_or_default();
+        let after_ids: BTreeSet<i64> = after_objs
+            .map(|v| v.iter().map(|o| o.id).collect())
+            .unwrap_or_default();
+
+        // Stable, sorted union of ids so output order is deterministic.
+        for id in before_ids.union(&after_ids).copied() {
+            if ignore.skips_object(group, id) {
+                continue;
+            }
+
+            let in_before = before_ids.contains(&id);
+            let in_after = after_ids.contains(&id);
+
+            match (in_before, in_after) {
+                (false, true) => diff.objects.push(ObjectDiff {
+                    group: group.clone(),
+                    id,
+                    display_name: after
+                        .index
+                        .id_to_display_name
+                        .get(&id)
+                        .cloned()
+                        .unwrap_or_default(),
+                    kind: DiffKind::Added,
+                    field_changes: Vec::new(),
+                }),
+                (true, false) => diff.objects.push(ObjectDiff {
+                    group: group.clone(),
+                    id,
+                    display_name: before
+                        .index
+                        .id_to_display_name
+                        .get(&id)
+                        .cloned()
+                        .unwrap_or_default(),
+                    kind: DiffKind::Removed,
+                    field_changes: Vec::new(),
+                }),
+                (true, true) => {
+                    let (Some(a), Some(b)) = (
+                        before.object_value_node(group, id),
+                        after.object_value_node(group, id),
+                    ) else {
+                        continue;
+                    };
+                    // Whole-subtree short-circuit: the overwhelming majority of
+                    // objects are unchanged and cost exactly one compare here.
+                    if a == b {
+                        continue;
+                    }
+                    let mut field_changes = Vec::new();
+                    diff_values(a, b, "", ignore, &mut field_changes);
+                    // If every concrete change was an ignored path, the object
+                    // is effectively unchanged and must not appear.
+                    if field_changes.is_empty() {
+                        continue;
+                    }
+                    diff.objects.push(ObjectDiff {
+                        group: group.clone(),
+                        id,
+                        display_name: after
+                            .index
+                            .id_to_display_name
+                            .get(&id)
+                            .cloned()
+                            .unwrap_or_default(),
+                        kind: DiffKind::Changed,
+                        field_changes,
+                    });
+                }
+                (false, false) => unreachable!("id came from the union of both sets"),
+            }
+        }
+    }
+
+    diff
+}
+
+/// Walk two matched `Value` subtrees and collect leaf/subtree changes as
+/// `FieldChange`s, honoring `ignore` path-prefix suppression. `base_path` is
+/// the accumulated path from the object root.
+pub(crate) fn diff_values(
+    before: &TiValue,
+    after: &TiValue,
+    base_path: &str,
+    ignore: &IgnoreRules,
+    out: &mut Vec<FieldChange>,
+) {
+    // Equal subtrees produce nothing; this is the cheap recursive short-circuit.
+    if before == after {
+        return;
+    }
+    if !base_path.is_empty() && ignore.skips_path(base_path) {
+        return;
+    }
+
+    match (before, after) {
+        (TiValue::Object(a), TiValue::Object(b)) => {
+            // Changed/removed keys, preserving `before` key order.
+            for (k, av) in a {
+                let path = join_key(base_path, k);
+                match b.get(k) {
+                    Some(bv) => diff_values(av, bv, &path, ignore, out),
+                    None => {
+                        if !ignore.skips_path(&path) {
+                            out.push(FieldChange {
+                                path,
+                                before: Some(av.clone()),
+                                after: None,
+                            });
+                        }
+                    }
+                }
+            }
+            // Added keys, in `after` order.
+            for (k, bv) in b {
+                if a.contains_key(k) {
+                    continue;
+                }
+                let path = join_key(base_path, k);
+                if !ignore.skips_path(&path) {
+                    out.push(FieldChange {
+                        path,
+                        before: None,
+                        after: Some(bv.clone()),
+                    });
+                }
+            }
+        }
+        (TiValue::Array(a), TiValue::Array(b)) => {
+            let max = a.len().max(b.len());
+            for i in 0..max {
+                let path = format!("{base_path}[{i}]");
+                match (a.get(i), b.get(i)) {
+                    (Some(av), Some(bv)) => diff_values(av, bv, &path, ignore, out),
+                    (Some(av), None) => {
+                        if !ignore.skips_path(&path) {
+                            out.push(FieldChange {
+                                path,
+                                before: Some(av.clone()),
+                                after: None,
+                            });
+                        }
+                    }
+                    (None, Some(bv)) => {
+                        if !ignore.skips_path(&path) {
+                            out.push(FieldChange {
+                                path,
+                                before: None,
+                                after: Some(bv.clone()),
+                            });
+                        }
+                    }
+                    (None, None) => unreachable!(),
+                }
+            }
+        }
+        // Type mismatch or differing primitives: a single leaf change.
+        _ => out.push(FieldChange {
+            path: base_path.to_string(),
+            before: Some(before.clone()),
+            after: Some(after.clone()),
+        }),
+    }
+}
+
+/// Join a base path with a child object key, using `.` only when nested.
+fn join_key(base: &str, key: &str) -> String {
+    if base.is_empty() {
+        key.to_string()
+    } else {
+        format!("{base}.{key}")
+    }
+}
+
+/// Load the `after` save from disk transiently, diff it against an
+/// already-loaded `before`, and drop the `after` tree before returning. This
+/// is the "Compare against..." entry point: the editor keeps `before` resident
+/// and never holds two full save trees at once, only the (small) `SaveDiff`
+/// survives.
+pub fn diff_against_path(
+    before: &LoadedSave,
+    after_path: &std::path::Path,
+    ignore: &IgnoreRules,
+) -> anyhow::Result<SaveDiff> {
+    let after = LoadedSave::load_path(after_path)?;
+    let diff = diff_saves(before, &after, ignore);
+    drop(after); // explicit: release the second tree before we return.
+    Ok(diff)
+}
+
+/// Load both saves from disk, diff them, and drop both trees, returning only
+/// the `SaveDiff`. Convenience for headless/library callers (and the self-test)
+/// that have two paths and want just the delta.
+pub fn diff_paths(
+    before_path: &std::path::Path,
+    after_path: &std::path::Path,
+    ignore: &IgnoreRules,
+) -> anyhow::Result<SaveDiff> {
+    let before = LoadedSave::load_path(before_path)?;
+    diff_against_path(&before, after_path, ignore)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::statics;
+    use crate::value::TiNumber;
+    use indexmap::IndexMap;
+
+    // --- helpers to build TI-shaped saves -----------------------------------
+
+    fn num(n: i64) -> TiValue {
+        TiValue::Number(TiNumber::I64(n))
+    }
+
+    fn obj(pairs: Vec<(&str, TiValue)>) -> TiValue {
+        let mut m = IndexMap::new();
+        for (k, v) in pairs {
+            m.insert(k.to_string(), v);
+        }
+        TiValue::Object(m)
+    }
+
+    /// One `{ Key:{value:id}, Value:{..props} }` entry.
+    fn entry(id: i64, props: Vec<(&str, TiValue)>) -> TiValue {
+        obj(vec![
+            (
+                statics::TI_FIELD_KEY_CAP,
+                obj(vec![(statics::TI_REF_FIELD_VALUE, num(id))]),
+            ),
+            (statics::TI_FIELD_VALUE_CAP, obj(props)),
+        ])
+    }
+
+    /// A full save root: `{ gamestates: { group: [entries...] } }`.
+    fn save_with(groups: Vec<(&str, Vec<TiValue>)>) -> LoadedSave {
+        let mut gs = IndexMap::new();
+        for (g, items) in groups {
+            gs.insert(g.to_string(), TiValue::Array(items));
+        }
+        let root = obj(vec![(statics::TI_GAMESTATES, TiValue::Object(gs))]);
+        LoadedSave::from_root_for_test(root)
+    }
+
+    const G: &str = "PavonisInteractive.TerraInvicta.TITest";
+
+    // --- diff_values (recursive field walker) -------------------------------
+
+    #[test]
+    fn diff_values_reports_changed_primitive_leaf() {
+        let before = obj(vec![
+            ("money", num(100)),
+            ("name", TiValue::String("a".into())),
+        ]);
+        let after = obj(vec![
+            ("money", num(250)),
+            ("name", TiValue::String("a".into())),
+        ]);
+        let mut out = Vec::new();
+        diff_values(&before, &after, "", &IgnoreRules::new(), &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, "money");
+        assert_eq!(out[0].before, Some(num(100)));
+        assert_eq!(out[0].after, Some(num(250)));
+    }
+
+    #[test]
+    fn diff_values_reports_added_and_removed_keys() {
+        let before = obj(vec![("keep", num(1)), ("gone", num(9))]);
+        let after = obj(vec![("keep", num(1)), ("fresh", num(7))]);
+        let mut out = Vec::new();
+        diff_values(&before, &after, "", &IgnoreRules::new(), &mut out);
+        let removed = out.iter().find(|c| c.path == "gone").unwrap();
+        assert_eq!(removed.before, Some(num(9)));
+        assert_eq!(removed.after, None);
+        let added = out.iter().find(|c| c.path == "fresh").unwrap();
+        assert_eq!(added.before, None);
+        assert_eq!(added.after, Some(num(7)));
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn diff_values_recurses_into_nested_objects_with_dotted_path() {
+        let before = obj(vec![("res", obj(vec![("money", num(1))]))]);
+        let after = obj(vec![("res", obj(vec![("money", num(2))]))]);
+        let mut out = Vec::new();
+        diff_values(&before, &after, "", &IgnoreRules::new(), &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, "res.money");
+    }
+
+    #[test]
+    fn diff_values_compares_arrays_positionally_with_bracket_path() {
+        let before = obj(vec![("hist", TiValue::Array(vec![num(1), num(2)]))]);
+        let after = obj(vec![("hist", TiValue::Array(vec![num(1), num(2), num(3)]))]);
+        let mut out = Vec::new();
+        diff_values(&before, &after, "", &IgnoreRules::new(), &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, "hist[2]");
+        assert_eq!(out[0].before, None);
+        assert_eq!(out[0].after, Some(num(3)));
+    }
+
+    #[test]
+    fn diff_values_honors_path_prefix_ignore() {
+        let before = obj(vec![
+            ("historyGDP", TiValue::Array(vec![num(1)])),
+            ("money", num(1)),
+        ]);
+        let after = obj(vec![
+            ("historyGDP", TiValue::Array(vec![num(1), num(2)])),
+            ("money", num(5)),
+        ]);
+        let ignore = IgnoreRules::new().ignore_path_prefix("historyGDP");
+        let mut out = Vec::new();
+        diff_values(&before, &after, "", &ignore, &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, "money");
+    }
+
+    #[test]
+    fn diff_values_equal_subtrees_produce_nothing() {
+        let v = obj(vec![("a", num(1)), ("b", obj(vec![("c", num(2))]))]);
+        let mut out = Vec::new();
+        diff_values(&v, &v.clone(), "", &IgnoreRules::new(), &mut out);
+        assert!(out.is_empty());
+    }
+
+    // --- diff_saves (object alignment) --------------------------------------
+
+    #[test]
+    fn diff_saves_detects_added_and_removed_objects_by_id() {
+        let before = save_with(vec![(G, vec![entry(1, vec![("hp", num(1))])])]);
+        let after = save_with(vec![(
+            G,
+            vec![
+                entry(1, vec![("hp", num(1))]),
+                entry(2, vec![("hp", num(5))]),
+            ],
+        )]);
+        let diff = diff_saves(&before, &after, &IgnoreRules::new());
+        assert_eq!(diff.count_kind(DiffKind::Added), 1);
+        assert_eq!(diff.count_kind(DiffKind::Removed), 0);
+        let added = diff
+            .objects
+            .iter()
+            .find(|o| o.kind == DiffKind::Added)
+            .unwrap();
+        assert_eq!(added.id, 2);
+        assert_eq!(added.group, G);
+    }
+
+    #[test]
+    fn diff_saves_aligns_by_id_not_position() {
+        // Same two objects, reversed array order: must produce zero diff.
+        let before = save_with(vec![(
+            G,
+            vec![
+                entry(1, vec![("hp", num(1))]),
+                entry(2, vec![("hp", num(2))]),
+            ],
+        )]);
+        let after = save_with(vec![(
+            G,
+            vec![
+                entry(2, vec![("hp", num(2))]),
+                entry(1, vec![("hp", num(1))]),
+            ],
+        )]);
+        let diff = diff_saves(&before, &after, &IgnoreRules::new());
+        assert!(
+            diff.is_empty(),
+            "reordering objects must not register as a change"
+        );
+    }
+
+    #[test]
+    fn diff_saves_collects_field_changes_for_changed_object() {
+        let before = save_with(vec![(G, vec![entry(1, vec![("hp", num(10))])])]);
+        let after = save_with(vec![(G, vec![entry(1, vec![("hp", num(99))])])]);
+        let diff = diff_saves(&before, &after, &IgnoreRules::new());
+        assert_eq!(diff.count_kind(DiffKind::Changed), 1);
+        let changed = &diff.objects[0];
+        assert_eq!(changed.id, 1);
+        assert_eq!(changed.field_changes.len(), 1);
+        assert_eq!(changed.field_changes[0].path, "hp");
+    }
+
+    #[test]
+    fn diff_saves_reports_added_and_removed_groups() {
+        let before = save_with(vec![(G, vec![entry(1, vec![("hp", num(1))])])]);
+        let other = "PavonisInteractive.TerraInvicta.TIOther";
+        let after = save_with(vec![
+            (G, vec![entry(1, vec![("hp", num(1))])]),
+            (other, vec![entry(2, vec![("hp", num(1))])]),
+        ]);
+        let diff = diff_saves(&before, &after, &IgnoreRules::new());
+        assert_eq!(diff.groups_added, vec![other.to_string()]);
+        assert!(diff.groups_removed.is_empty());
+    }
+
+    #[test]
+    fn diff_saves_skips_ignored_group_entirely() {
+        let before = save_with(vec![(G, vec![entry(1, vec![("hp", num(1))])])]);
+        let after = save_with(vec![(G, vec![entry(1, vec![("hp", num(2))])])]);
+        let ignore = IgnoreRules::new().ignore_group(G);
+        let diff = diff_saves(&before, &after, &ignore);
+        assert!(
+            diff.is_empty(),
+            "ignored group must produce no object diffs"
+        );
+    }
+
+    #[test]
+    fn diff_saves_drops_changed_object_when_only_ignored_paths_differ() {
+        let before = save_with(vec![(
+            G,
+            vec![entry(1, vec![("historyGDP", TiValue::Array(vec![num(1)]))])],
+        )]);
+        let after = save_with(vec![(
+            G,
+            vec![entry(
+                1,
+                vec![("historyGDP", TiValue::Array(vec![num(1), num(2)]))],
+            )],
+        )]);
+        let ignore = IgnoreRules::new().ignore_path_prefix("historyGDP");
+        let diff = diff_saves(&before, &after, &ignore);
+        assert!(
+            diff.is_empty(),
+            "object whose only changes are ignored paths must not appear as Changed"
+        );
+    }
+
+    // --- IgnoreRules path matching ------------------------------------------
+
+    #[test]
+    fn ignore_path_prefix_is_segment_aware() {
+        let r = IgnoreRules::new().ignore_path_prefix("historyGDP");
+        assert!(r.skips_path("historyGDP"));
+        assert!(r.skips_path("historyGDP[3]"));
+        assert!(r.skips_path("historyGDP.foo"));
+        // Must NOT match a different field that merely shares the prefix string.
+        assert!(!r.skips_path("historyGDProjection"));
+    }
+
+    #[test]
+    fn ignore_field_namespace_catches_any_history_field() {
+        // The noise preset must suppress EVERY history* time series, including
+        // ones not seen during calibration (e.g. historyWarStatus appears only
+        // when a nation is at war). A namespace rule catches them all by the
+        // first path segment's name prefix.
+        let r = IgnoreRules::new().ignore_field_namespace("history");
+        assert!(r.skips_path("historyGDP[3]"));
+        assert!(r.skips_path("historyWarStatus[19]"));
+        assert!(r.skips_path("historyArmyStrength"));
+        // Nested under a history array is still history churn.
+        assert!(r.skips_path("historyPublicOpinion[2].Resist"));
+        // A non-history field is untouched.
+        assert!(!r.skips_path("economyScore"));
+        assert!(!r.skips_path("publicOpinion.Resist"));
+    }
+
+    #[test]
+    fn noise_preset_suppresses_uncalibrated_history_war_status() {
+        // Regression: historyWarStatus leaked through the noise preset because
+        // the preset enumerated specific field names. The namespace rule fixes
+        // it. Build an object whose only change is historyWarStatus and assert
+        // the preset empties it out.
+        let before = save_with(vec![(
+            "TINationState",
+            vec![entry(
+                1,
+                vec![("historyWarStatus", TiValue::Array(vec![num(299)]))],
+            )],
+        )]);
+        let after = save_with(vec![(
+            "TINationState",
+            vec![entry(
+                1,
+                vec![("historyWarStatus", TiValue::Array(vec![num(299), num(0)]))],
+            )],
+        )]);
+        let full = diff_saves(&before, &after, &IgnoreRules::new());
+        assert_eq!(full.count_kind(DiffKind::Changed), 1);
+        let filtered = full.filtered(&IgnoreRules::default_noise_preset());
+        assert!(
+            filtered.is_empty(),
+            "noise preset must suppress historyWarStatus churn, got {:?}",
+            filtered.objects
+        );
+    }
+
+    // --- SaveDiff::filtered (live re-filter of a cached full diff) -----------
+
+    #[test]
+    fn filtered_drops_objects_in_ignored_group() {
+        let before = save_with(vec![(G, vec![entry(1, vec![("hp", num(1))])])]);
+        let after = save_with(vec![(G, vec![entry(1, vec![("hp", num(2))])])]);
+        // Full diff with no ignore: one Changed object.
+        let full = diff_saves(&before, &after, &IgnoreRules::new());
+        assert_eq!(full.count_kind(DiffKind::Changed), 1);
+        // Re-filter the cached diff by group: now empty.
+        let filtered = full.filtered(&IgnoreRules::new().ignore_group(G));
+        assert!(filtered.is_empty());
+        // Original is untouched (filtering is non-destructive).
+        assert_eq!(full.count_kind(DiffKind::Changed), 1);
+    }
+
+    #[test]
+    fn filtered_drops_field_changes_and_empties_objects() {
+        let before = save_with(vec![(
+            G,
+            vec![entry(
+                1,
+                vec![
+                    ("historyGDP", TiValue::Array(vec![num(1)])),
+                    ("money", num(1)),
+                ],
+            )],
+        )]);
+        let after = save_with(vec![(
+            G,
+            vec![entry(
+                1,
+                vec![
+                    ("historyGDP", TiValue::Array(vec![num(1), num(2)])),
+                    ("money", num(9)),
+                ],
+            )],
+        )]);
+        let full = diff_saves(&before, &after, &IgnoreRules::new());
+        // Both money and historyGDP changed.
+        assert_eq!(full.objects[0].field_changes.len(), 2);
+
+        // Filter out historyGDP: object survives with only the money change.
+        let f1 = full.filtered(&IgnoreRules::new().ignore_path_prefix("historyGDP"));
+        assert_eq!(f1.objects.len(), 1);
+        assert_eq!(f1.objects[0].field_changes.len(), 1);
+        assert_eq!(f1.objects[0].field_changes[0].path, "money");
+
+        // Filter out both paths: object has no surviving changes, so it drops.
+        let f2 = full.filtered(
+            &IgnoreRules::new()
+                .ignore_path_prefix("historyGDP")
+                .ignore_path_prefix("money"),
+        );
+        assert!(f2.is_empty());
+    }
+
+    #[test]
+    fn filtered_keeps_added_removed_objects_unless_group_ignored() {
+        let before = save_with(vec![(G, vec![entry(1, vec![("hp", num(1))])])]);
+        let after = save_with(vec![(
+            G,
+            vec![
+                entry(1, vec![("hp", num(1))]),
+                entry(2, vec![("hp", num(5))]),
+            ],
+        )]);
+        let full = diff_saves(&before, &after, &IgnoreRules::new());
+        assert_eq!(full.count_kind(DiffKind::Added), 1);
+        // Added object has no field changes, but must NOT be dropped by a
+        // path-only ignore — only a group/id ignore removes it.
+        let f1 = full.filtered(&IgnoreRules::new().ignore_path_prefix("hp"));
+        assert_eq!(f1.count_kind(DiffKind::Added), 1);
+        let f2 = full.filtered(&IgnoreRules::new().ignore_id(2));
+        assert_eq!(f2.count_kind(DiffKind::Added), 0);
+    }
+
+    // --- SaveDiff::view_filtered (Compare window visible subset) -------------
+
+    #[test]
+    fn view_filtered_can_show_only_selected_groups() {
+        let other_group = "PavonisInteractive.TerraInvicta.TIOther";
+        let before = save_with(vec![
+            (G, vec![entry(1, vec![("hp", num(1))])]),
+            (other_group, vec![entry(2, vec![("hp", num(1))])]),
+        ]);
+        let after = save_with(vec![
+            (G, vec![entry(1, vec![("hp", num(2))])]),
+            (other_group, vec![entry(2, vec![("hp", num(2))])]),
+        ]);
+        let full = diff_saves(&before, &after, &IgnoreRules::new());
+        assert_eq!(full.count_kind(DiffKind::Changed), 2);
+
+        let selected = std::collections::BTreeSet::from([G.to_string()]);
+        let view = full.view_filtered(Some(&selected), "");
+        assert_eq!(view.objects.len(), 1);
+        assert_eq!(view.objects[0].group, G);
+    }
+
+    #[test]
+    fn view_filtered_empty_group_selection_hides_every_object() {
+        let before = save_with(vec![(G, vec![entry(1, vec![("hp", num(1))])])]);
+        let after = save_with(vec![(G, vec![entry(1, vec![("hp", num(2))])])]);
+        let full = diff_saves(&before, &after, &IgnoreRules::new());
+        let selected = std::collections::BTreeSet::new();
+        let view = full.view_filtered(Some(&selected), "");
+        assert!(view.is_empty());
+    }
+
+    #[test]
+    fn view_filtered_search_matches_object_metadata_or_field_details() {
+        let before = save_with(vec![
+            (
+                G,
+                vec![entry(
+                    1,
+                    vec![
+                        (
+                            statics::TI_PROP_DISPLAY_NAME,
+                            TiValue::String("Canada".into()),
+                        ),
+                        ("economyScore", num(12)),
+                        ("cohesion", num(5)),
+                    ],
+                )],
+            ),
+            (
+                "PavonisInteractive.TerraInvicta.TIFaction",
+                vec![entry(
+                    2,
+                    vec![(
+                        statics::TI_PROP_DISPLAY_NAME,
+                        TiValue::String("Resistance".into()),
+                    )],
+                )],
+            ),
+        ]);
+        let after = save_with(vec![
+            (
+                G,
+                vec![entry(
+                    1,
+                    vec![
+                        (
+                            statics::TI_PROP_DISPLAY_NAME,
+                            TiValue::String("Canada".into()),
+                        ),
+                        ("economyScore", num(13)),
+                        ("cohesion", num(6)),
+                    ],
+                )],
+            ),
+            (
+                "PavonisInteractive.TerraInvicta.TIFaction",
+                vec![entry(
+                    2,
+                    vec![(
+                        statics::TI_PROP_DISPLAY_NAME,
+                        TiValue::String("Humanity First".into()),
+                    )],
+                )],
+            ),
+        ]);
+        let full = diff_saves(&before, &after, &IgnoreRules::new());
+
+        // Object metadata match: keep the whole matching object and all its fields.
+        let canada = full.view_filtered(None, "canada");
+        assert_eq!(canada.objects.len(), 1);
+        assert_eq!(canada.objects[0].display_name, "Canada");
+        assert_eq!(canada.objects[0].field_changes.len(), 2);
+
+        // Field match: keep only matching fields inside otherwise-matching objects.
+        let economy = full.view_filtered(None, "economy");
+        assert_eq!(economy.objects.len(), 1);
+        assert_eq!(economy.objects[0].field_changes.len(), 1);
+        assert_eq!(economy.objects[0].field_changes[0].path, "economyScore");
+
+        // Value match: searching the before or after value should find the faction rename.
+        let resistance = full.view_filtered(None, "resistance");
+        assert_eq!(resistance.objects.len(), 1);
+        assert_eq!(resistance.objects[0].display_name, "Humanity First");
+        let humanity = full.view_filtered(None, "humanity");
+        assert_eq!(humanity.objects.len(), 1);
+        assert_eq!(humanity.objects[0].display_name, "Humanity First");
+    }
+}

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,8 +1,9 @@
+use crate::diff::{self, IgnoreRules, SaveDiff};
 use crate::statics;
 use crate::{LoadedSave, TiValue};
 use eframe::egui;
 use egui_extras::{Column, TableBuilder};
-use std::{path::PathBuf, sync::OnceLock};
+use std::{collections::BTreeSet, path::PathBuf, sync::OnceLock};
 
 #[derive(Clone, Debug)]
 enum PublicOpinionDrag {
@@ -117,6 +118,25 @@ struct TiseApp {
 
     // Feature: filter TICouncilorState objects by faction.
     councilor_faction_filter: Option<i64>,
+
+    // Feature: Compare Saves (structural diff against another save file).
+    diff_open: bool,
+    /// Full, unfiltered diff cached from the last Compare. The window re-derives
+    /// the visible view via `SaveDiff::filtered`, so toggling ignore checkboxes
+    /// never re-reads the files.
+    diff_full: Option<SaveDiff>,
+    /// Path of the save we compared against (for the window header).
+    diff_other_path: Option<PathBuf>,
+    /// "Hide per-turn noise" preset toggle (on by default).
+    diff_hide_noise: bool,
+    /// Positive group filter: when true, show every changed group. When false,
+    /// show only the groups checked in `diff_visible_groups`.
+    diff_show_all_groups: bool,
+    /// Groups the user has explicitly checked to keep visible when
+    /// `diff_show_all_groups` is false.
+    diff_visible_groups: BTreeSet<String>,
+    /// Case-insensitive search/filter text for object metadata and fields.
+    diff_search: String,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -1548,6 +1568,315 @@ impl TiseApp {
         self.save_file_as();
     }
 
+    /// Open a file picker for the "other" save, diff it against the currently
+    /// loaded save, and cache the full (unfiltered) result. The second save's
+    /// tree is dropped inside `diff_against_path`, so we never hold two full
+    /// saves resident; only the small `SaveDiff` survives.
+    fn compare_against(&mut self) {
+        let Some(before) = self.save.as_ref() else {
+            self.last_error = Some(statics::EN_DIFF_ERR_NO_SAVE.to_string());
+            return;
+        };
+        let Some(path) = self.file_dialog().pick_file() else {
+            return;
+        };
+        match diff::diff_against_path(before, &path, &IgnoreRules::new()) {
+            Ok(full) => {
+                self.dialog_dir = path.parent().map(PathBuf::from);
+                self.diff_other_path = Some(path);
+                self.diff_full = Some(full);
+                self.diff_hide_noise = true;
+                self.diff_show_all_groups = true;
+                self.diff_visible_groups.clear();
+                self.diff_search.clear();
+                self.diff_open = true;
+                self.last_error = None;
+            }
+            Err(e) => {
+                self.last_error = Some(format!("Failed to compare: {e:#}"));
+            }
+        }
+    }
+
+    /// Build the active `IgnoreRules` for the diff window from the noise toggle.
+    /// Group visibility and search are positive view filters layered on top via
+    /// `SaveDiff::view_filtered`, not destructive ignore rules.
+    fn diff_ignore_rules(&self) -> IgnoreRules {
+        if self.diff_hide_noise {
+            IgnoreRules::default_noise_preset()
+        } else {
+            IgnoreRules::new()
+        }
+    }
+
+    /// Short display name for a gamestate group (strips the long TI namespace).
+    fn diff_group_label(group: &str) -> &str {
+        LoadedSave::group_display_name(group)
+    }
+
+    /// Render the Compare Saves window. The full diff is cached; this re-derives
+    /// the visible view each frame from the cheap pure filters, so changing the
+    /// search box or group selection never re-reads the files.
+    fn show_diff_window(&mut self, ctx: &egui::Context) {
+        let base = self
+            .diff_full
+            .as_ref()
+            .map(|full| full.filtered(&self.diff_ignore_rules()));
+        let changed_groups = base
+            .as_ref()
+            .map(SaveDiff::changed_groups)
+            .unwrap_or_default();
+
+        let other_name = self
+            .diff_other_path
+            .as_ref()
+            .and_then(|p| p.file_name())
+            .map(|n| n.to_string_lossy().into_owned());
+        let this_name = self
+            .save
+            .as_ref()
+            .and_then(|s| s.source_path.as_ref())
+            .and_then(|p| p.file_name())
+            .map(|n| n.to_string_lossy().into_owned());
+
+        let mut open = self.diff_open;
+        let mut hide_noise = self.diff_hide_noise;
+        let mut show_all_groups = self.diff_show_all_groups;
+        let mut visible_groups = self.diff_visible_groups.clone();
+        let mut search = self.diff_search.clone();
+
+        egui::Window::new(statics::EN_WINDOW_DIFF)
+            .collapsible(true)
+            .resizable(true)
+            .open(&mut open)
+            .default_width(980.0)
+            .default_height(700.0)
+            .show(ctx, |ui| {
+                let Some(base) = base.as_ref() else {
+                    ui.label(statics::EN_DIFF_NO_OTHER);
+                    return;
+                };
+
+                // Capture the window's granted body height up front. A
+                // horizontal layout hugs its content height, so without forcing
+                // the row to claim the full height the nested scroll area only
+                // ever gets content-height to fill and the window snaps back to
+                // content size (defeating vertical resize). set_min_height makes
+                // the row, and therefore the results scroll area, fill the body.
+                let body_height = ui.available_height();
+
+                ui.horizontal(|ui| {
+                    ui.set_min_width(940.0);
+                    ui.set_min_height(body_height);
+
+                    // Left rail: filters and group selection.
+                    ui.vertical(|ui| {
+                        ui.set_width(260.0);
+                        ui.heading(statics::EN_DIFF_IGNORE_HEADER);
+                        ui.checkbox(&mut hide_noise, statics::EN_DIFF_IGNORE_NOISE_PRESET);
+                        ui.separator();
+
+                        ui.label(statics::EN_DIFF_SEARCH_LABEL);
+                        ui.add(
+                            egui::TextEdit::singleline(&mut search)
+                                .hint_text(statics::EN_DIFF_SEARCH_HINT)
+                                .desired_width(240.0),
+                        );
+
+                        ui.separator();
+                        if ui
+                            .checkbox(&mut show_all_groups, statics::EN_DIFF_SHOW_ALL_GROUPS)
+                            .changed()
+                            && show_all_groups
+                        {
+                            visible_groups.clear();
+                        }
+                        ui.horizontal(|ui| {
+                            if ui.button(statics::EN_DIFF_BTN_IGNORE_ALL_GROUPS).clicked() {
+                                show_all_groups = false;
+                                visible_groups.clear();
+                            }
+                            if ui.button(statics::EN_DIFF_BTN_SHOW_ALL_GROUPS).clicked() {
+                                show_all_groups = true;
+                                visible_groups.clear();
+                            }
+                        });
+
+                        if !show_all_groups {
+                            ui.label(statics::EN_DIFF_VISIBLE_GROUPS_LABEL);
+                            egui::ScrollArea::vertical()
+                                .max_height(460.0)
+                                .id_salt("diff_visible_groups")
+                                .show(ui, |ui| {
+                                    for g in &changed_groups {
+                                        let mut on = visible_groups.contains(g);
+                                        if ui.checkbox(&mut on, Self::diff_group_label(g)).changed()
+                                        {
+                                            if on {
+                                                visible_groups.insert(g.clone());
+                                            } else {
+                                                visible_groups.remove(g);
+                                            }
+                                        }
+                                    }
+                                });
+                        }
+                    });
+
+                    ui.separator();
+
+                    // Right rail: summary and results.
+                    ui.vertical(|ui| {
+                        let group_filter = if show_all_groups {
+                            None
+                        } else {
+                            Some(&visible_groups)
+                        };
+                        let view = base.view_filtered(group_filter, &search);
+
+                        if let Some(name) = &this_name {
+                            ui.label(format!("{} {}", statics::EN_DIFF_PREFIX_BEFORE, name));
+                        }
+                        if let Some(name) = &other_name {
+                            ui.label(format!("{} {}", statics::EN_DIFF_PREFIX_AFTER, name));
+                        }
+                        let (added, removed, changed) = view.summary_counts();
+                        ui.horizontal(|ui| {
+                            ui.colored_label(
+                                egui::Color32::LIGHT_GREEN,
+                                format!("{} {}", added, statics::EN_DIFF_LABEL_ADDED),
+                            );
+                            ui.colored_label(
+                                egui::Color32::LIGHT_RED,
+                                format!("{} {}", removed, statics::EN_DIFF_LABEL_REMOVED),
+                            );
+                            ui.colored_label(
+                                egui::Color32::YELLOW,
+                                format!("{} {}", changed, statics::EN_DIFF_LABEL_CHANGED),
+                            );
+                        });
+
+                        if !view.groups_added.is_empty() {
+                            ui.label(format!(
+                                "{} {}",
+                                statics::EN_DIFF_GROUPS_ADDED,
+                                view.groups_added
+                                    .iter()
+                                    .map(|g| Self::diff_group_label(g))
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            ));
+                        }
+                        if !view.groups_removed.is_empty() {
+                            ui.label(format!(
+                                "{} {}",
+                                statics::EN_DIFF_GROUPS_REMOVED,
+                                view.groups_removed
+                                    .iter()
+                                    .map(|g| Self::diff_group_label(g))
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            ));
+                        }
+
+                        ui.separator();
+
+                        if view.is_empty() {
+                            if base.is_empty() {
+                                ui.label(statics::EN_DIFF_IDENTICAL);
+                            } else {
+                                ui.label(statics::EN_DIFF_NO_MATCHES);
+                            }
+                            return;
+                        }
+
+                        egui::ScrollArea::vertical()
+                            .id_salt("diff_objects")
+                            .auto_shrink([false, false])
+                            .max_height(ui.available_height())
+                            .show(ui, |ui| {
+                                for obj in &view.objects {
+                                    let (glyph, color) = Self::diff_kind_visual(obj.kind);
+                                    let title = if obj.display_name.is_empty() {
+                                        format!(
+                                            "{}  {} #{}",
+                                            glyph,
+                                            Self::diff_group_label(&obj.group),
+                                            obj.id
+                                        )
+                                    } else {
+                                        format!(
+                                            "{}  {} #{}  ({})",
+                                            glyph,
+                                            Self::diff_group_label(&obj.group),
+                                            obj.id,
+                                            obj.display_name
+                                        )
+                                    };
+
+                                    if obj.field_changes.is_empty() {
+                                        ui.label(
+                                            egui::RichText::new(title).monospace().color(color),
+                                        );
+                                    } else {
+                                        egui::CollapsingHeader::new(
+                                            egui::RichText::new(title).monospace().color(color),
+                                        )
+                                        .id_salt(("diff_obj", &obj.group, obj.id))
+                                        .show(ui, |ui| {
+                                            for fc in &obj.field_changes {
+                                                let before =
+                                                    Self::diff_value_preview(fc.before.as_ref());
+                                                let after =
+                                                    Self::diff_value_preview(fc.after.as_ref());
+                                                ui.label(
+                                                    egui::RichText::new(format!(
+                                                        "{:<38}  {:<62} ->  {}",
+                                                        fc.path, before, after
+                                                    ))
+                                                    .monospace(),
+                                                );
+                                            }
+                                        });
+                                    }
+                                }
+                            });
+                    });
+                });
+            });
+
+        self.diff_open = open;
+        self.diff_hide_noise = hide_noise;
+        self.diff_show_all_groups = show_all_groups;
+        self.diff_visible_groups = visible_groups;
+        self.diff_search = search;
+    }
+
+    fn diff_kind_visual(kind: crate::DiffKind) -> (&'static str, egui::Color32) {
+        match kind {
+            crate::DiffKind::Added => (statics::EN_DIFF_KIND_ADDED, egui::Color32::LIGHT_GREEN),
+            crate::DiffKind::Removed => (statics::EN_DIFF_KIND_REMOVED, egui::Color32::LIGHT_RED),
+            crate::DiffKind::Changed => (statics::EN_DIFF_KIND_CHANGED, egui::Color32::YELLOW),
+        }
+    }
+
+    /// Compact one-line preview of a value side in a field change.
+    fn diff_value_preview(v: Option<&TiValue>) -> String {
+        match v {
+            None => statics::EN_LITERAL_MISSING.to_string(),
+            Some(val) => {
+                let s = val.to_json5_compact();
+                const MAX: usize = 60;
+                if s.chars().count() > MAX {
+                    let truncated: String = s.chars().take(MAX).collect();
+                    format!("{truncated}...")
+                } else {
+                    s
+                }
+            }
+        }
+    }
+
     fn save_file_as(&mut self) {
         let mut dlg = self.file_dialog();
         if let Some(save) = self.save.as_ref()
@@ -2962,6 +3291,13 @@ impl eframe::App for TiseApp {
                     self.save_file();
                 }
 
+                if ui
+                    .add_enabled(has_save, egui::Button::new(statics::EN_BTN_COMPARE))
+                    .clicked()
+                {
+                    self.compare_against();
+                }
+
                 if ui.button(statics::EN_BTN_ABOUT).clicked() {
                     self.about_open = true;
                 }
@@ -3133,6 +3469,10 @@ impl eframe::App for TiseApp {
                     );
                 });
             self.about_open = open;
+        }
+
+        if self.diff_open {
+            self.show_diff_window(ctx);
         }
 
         if let Some(err) = self.last_error.clone() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,16 @@
 //! Provides JSON5 parsing/serialization tailored for Terra Invicta save files, including
 //! round-trip guarantees and efficient indexing.
 
+pub mod diff;
 mod gui;
 mod save;
 pub mod statics;
 mod value;
 
+pub use diff::{
+    DiffKind, FieldChange, IgnoreRules, ObjectDiff, SaveDiff, diff_against_path, diff_paths,
+    diff_saves,
+};
 pub use gui::run_gui;
 pub use save::{LoadedSave, SaveFormat};
 pub use value::TiValue;

--- a/src/save.rs
+++ b/src/save.rs
@@ -201,6 +201,21 @@ impl LoadedSave {
         Some(value)
     }
 
+    /// Returns the `Value` node of an object as a `&TiValue` (typically a
+    /// `TiValue::Object`). Unlike [`get_object_value`], this hands back the
+    /// node itself rather than the inner map, which lets callers compare or
+    /// walk whole subtrees with `TiValue`'s `PartialEq`. Used by the save-diff.
+    pub fn object_value_node(&self, group: &str, object_id: i64) -> Option<&TiValue> {
+        let (real_group, idx) = self.index.id_lookup.get(&object_id)?.clone();
+        if real_group != group {
+            return None;
+        }
+        let gamestates = self.root.get(statics::TI_GAMESTATES)?.as_object()?;
+        let group_list = gamestates.get(group)?.as_array()?;
+        let entry = group_list.get(idx)?.as_object()?;
+        entry.get(statics::TI_FIELD_VALUE_CAP)
+    }
+
     pub fn save_to_path(&mut self, path: &Path) -> anyhow::Result<()> {
         let target_format = if path.extension().and_then(|e| e.to_str()) == Some("gz") {
             SaveFormat::GzipJson5

--- a/src/statics.rs
+++ b/src/statics.rs
@@ -82,6 +82,32 @@ pub const EN_BTN_CHANGE_TYPE: &str = "Change Type...";
 
 pub const EN_WINDOW_CHANGE_TYPE: &str = "Change Type";
 
+// Save comparison (diff) feature.
+pub const EN_BTN_COMPARE: &str = "Compare...";
+pub const EN_WINDOW_DIFF: &str = "Compare Saves";
+pub const EN_DIFF_NO_OTHER: &str = "Pick another save to compare against the loaded one.";
+pub const EN_DIFF_IDENTICAL: &str = "No differences (after ignore rules).";
+pub const EN_DIFF_PREFIX_BEFORE: &str = "Before:";
+pub const EN_DIFF_PREFIX_AFTER: &str = "After:";
+pub const EN_DIFF_LABEL_ADDED: &str = "added";
+pub const EN_DIFF_LABEL_REMOVED: &str = "removed";
+pub const EN_DIFF_LABEL_CHANGED: &str = "changed";
+pub const EN_DIFF_GROUPS_ADDED: &str = "Groups added:";
+pub const EN_DIFF_GROUPS_REMOVED: &str = "Groups removed:";
+pub const EN_DIFF_KIND_ADDED: &str = "+";
+pub const EN_DIFF_KIND_REMOVED: &str = "-";
+pub const EN_DIFF_KIND_CHANGED: &str = "~";
+pub const EN_DIFF_IGNORE_HEADER: &str = "Filters";
+pub const EN_DIFF_IGNORE_NOISE_PRESET: &str = "Hide per-turn noise (history/event logs)";
+pub const EN_DIFF_SEARCH_LABEL: &str = "Search:";
+pub const EN_DIFF_SEARCH_HINT: &str = "object, id, field, value...";
+pub const EN_DIFF_SHOW_ALL_GROUPS: &str = "Show all changed groups";
+pub const EN_DIFF_VISIBLE_GROUPS_LABEL: &str = "Visible groups:";
+pub const EN_DIFF_BTN_IGNORE_ALL_GROUPS: &str = "Ignore all";
+pub const EN_DIFF_BTN_SHOW_ALL_GROUPS: &str = "Show all";
+pub const EN_DIFF_NO_MATCHES: &str = "No differences match the current filters.";
+pub const EN_DIFF_ERR_NO_SAVE: &str = "Load a save first, then Compare against another.";
+
 pub const EN_LABEL_REFERENCE_ID: &str = "Reference ID:";
 pub const EN_LABEL_VALUE: &str = "Value";
 pub const EN_PREFIX_VALUE: &str = "Value: ";

--- a/tests/diff_paths.rs
+++ b/tests/diff_paths.rs
@@ -1,0 +1,79 @@
+//! Slice 4: two-save transient loading. The diff entry points that load from
+//! disk and drop the second tree, so the editor never holds two full saves.
+
+use std::path::Path;
+use tise::IgnoreRules;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+fn example(name: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join(name)
+}
+
+/// `diff_paths` must yield the same SaveDiff as loading both saves manually and
+/// calling `diff_saves`, while only returning the (small) delta.
+#[test]
+fn diff_paths_matches_in_memory_diff() -> Result<()> {
+    let a = example("PrunedGame.json");
+    let b = example("PrunedGameMore.json");
+    if !a.exists() || !b.exists() {
+        return Err("missing example fixtures".into());
+    }
+
+    let ignore = IgnoreRules::new();
+
+    // Reference: load both, diff in memory.
+    let before = tise::LoadedSave::load_path(&a)?;
+    let after = tise::LoadedSave::load_path(&b)?;
+    let reference = tise::diff_saves(&before, &after, &ignore);
+
+    // Path-based: loads transiently, drops trees, returns only the diff.
+    let via_paths = tise::diff_paths(&a, &b, &ignore)?;
+
+    assert_eq!(
+        via_paths, reference,
+        "diff_paths must equal the in-memory diff"
+    );
+    // Sanity: these two distinct saves actually differ, so the test has teeth.
+    assert!(
+        !reference.is_empty(),
+        "fixtures must differ for this test to mean anything"
+    );
+    Ok(())
+}
+
+/// `diff_against_path` keeps `before` resident and loads only `after`.
+#[test]
+fn diff_against_path_keeps_before_resident() -> Result<()> {
+    let a = example("PrunedGame.json");
+    let b = example("PrunedGameMore.json");
+    if !a.exists() || !b.exists() {
+        return Err("missing example fixtures".into());
+    }
+    let before = tise::LoadedSave::load_path(&a)?;
+    let diff = tise::diff_against_path(&before, &b, &IgnoreRules::new())?;
+
+    // `before` is still usable after the call (not consumed/dropped).
+    assert!(before.game_id().is_some(), "before save must remain usable");
+    assert_eq!(diff, tise::diff_paths(&a, &b, &IgnoreRules::new())?);
+    Ok(())
+}
+
+/// A missing `after` path is a clean Err, not a panic.
+#[test]
+fn diff_against_path_missing_file_is_err() -> Result<()> {
+    let a = example("PrunedGame.json");
+    if !a.exists() {
+        return Err("missing example fixture".into());
+    }
+    let before = tise::LoadedSave::load_path(&a)?;
+    let res = tise::diff_against_path(
+        &before,
+        Path::new("/nonexistent/does-not-exist.json"),
+        &IgnoreRules::new(),
+    );
+    assert!(res.is_err(), "missing after-file must return Err");
+    Ok(())
+}

--- a/tests/diff_selftest.rs
+++ b/tests/diff_selftest.rs
@@ -1,0 +1,124 @@
+//! Self-test: prove the structural diff isolates exactly the field an edit
+//! touched. This is the stronger successor to the line-count heuristic in
+//! roundtrip.rs — instead of counting changed text lines, it asserts the
+//! semantic [`SaveDiff`] contains precisely the intended `FieldChange`s.
+
+use std::path::Path;
+use tise::statics;
+use tise::{DiffKind, IgnoreRules, TiValue};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+/// Edit councilor 3896's three name fields, roundtrip through
+/// serialize -> reload, then diff the reloaded save against the pristine load.
+/// The diff must contain exactly one Changed object (the councilor) whose only
+/// field changes are the three names we set — nothing else.
+#[test]
+fn diff_isolates_exactly_the_edited_fields() -> Result<()> {
+    let input_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("LargeGame.json");
+    if !input_path.exists() {
+        return Err(format!("Missing test fixture: {input_path:?}").into());
+    }
+
+    // Pristine baseline.
+    let before = tise::LoadedSave::load_path(&input_path)?;
+
+    // Edited copy: load fresh, mutate three name fields, reserialize.
+    let mut edited = tise::LoadedSave::load_path(&input_path)?;
+    let Some(props) = edited.get_object_value_mut(statics::TI_GROUP_COUNCILOR_STATE, 3896) else {
+        return Err("Could not locate TICouncilorState ID 3896".into());
+    };
+    props.insert(
+        statics::TI_PROP_DISPLAY_NAME.to_string(),
+        TiValue::String("Bob Ross".to_string()),
+    );
+    props.insert(
+        statics::TI_PROP_FAMILY_NAME.to_string(),
+        TiValue::String("Ross".to_string()),
+    );
+    props.insert(
+        statics::TI_PROP_PERSONAL_NAME.to_string(),
+        TiValue::String("Bob".to_string()),
+    );
+    edited.mark_dirty();
+
+    // Roundtrip through bytes so we are diffing a genuinely reloaded save,
+    // exercising parse + index rebuild on the edited side.
+    let out_bytes = edited.save_bytes_for_format(tise::SaveFormat::Json5)?;
+    let dir = tempfile::tempdir()?;
+    let after_path = dir.path().join("edited.json");
+    std::fs::write(&after_path, &out_bytes)?;
+    let after = tise::LoadedSave::load_path(&after_path)?;
+
+    let diff = tise::diff_saves(&before, &after, &IgnoreRules::new());
+
+    // Exactly one object changed, and it is councilor 3896.
+    assert_eq!(
+        diff.objects.len(),
+        1,
+        "expected exactly one changed object, got {}: {:?}",
+        diff.objects.len(),
+        diff.objects
+            .iter()
+            .map(|o| (&o.group, o.id, o.kind))
+            .collect::<Vec<_>>()
+    );
+    assert!(diff.groups_added.is_empty());
+    assert!(diff.groups_removed.is_empty());
+
+    let obj = &diff.objects[0];
+    assert_eq!(obj.kind, DiffKind::Changed);
+    assert_eq!(obj.id, 3896);
+    assert_eq!(obj.group, statics::TI_GROUP_COUNCILOR_STATE);
+
+    // Exactly the three fields we set, with the right after-values.
+    let mut paths: Vec<&str> = obj.field_changes.iter().map(|c| c.path.as_str()).collect();
+    paths.sort_unstable();
+    assert_eq!(
+        paths,
+        vec!["displayName", "familyName", "personalName"],
+        "diff touched unexpected fields"
+    );
+
+    let after_of = |path: &str| -> Option<&TiValue> {
+        obj.field_changes
+            .iter()
+            .find(|c| c.path == path)
+            .and_then(|c| c.after.as_ref())
+    };
+    assert_eq!(
+        after_of("displayName"),
+        Some(&TiValue::String("Bob Ross".into()))
+    );
+    assert_eq!(
+        after_of("familyName"),
+        Some(&TiValue::String("Ross".into()))
+    );
+    assert_eq!(
+        after_of("personalName"),
+        Some(&TiValue::String("Bob".into()))
+    );
+
+    Ok(())
+}
+
+/// A save diffed against itself is empty — the fundamental invariant.
+#[test]
+fn diff_of_identical_saves_is_empty() -> Result<()> {
+    let input_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("PrunedGameMore.json");
+    if !input_path.exists() {
+        return Err(format!("Missing test fixture: {input_path:?}").into());
+    }
+    let a = tise::LoadedSave::load_path(&input_path)?;
+    let b = tise::LoadedSave::load_path(&input_path)?;
+    let diff = tise::diff_saves(&a, &b, &IgnoreRules::new());
+    assert!(
+        diff.is_empty(),
+        "identical saves must produce an empty diff"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Add a structural diff between two Terra Invicta saves and an egui window to drive it.

Diff core (src/diff.rs):
- Align objects by (group, id), not position; array reordering is invisible.
- Whole-subtree == short-circuit so unchanged objects cost one compare, keeping a 10k-object save tractable.
- Field-level changes addressed by dotted/bracketed JSON paths.
- IgnoreRules noise filter; default preset suppresses any history* series via a namespace rule (not an enumerated list, so uncalibrated series like historyWarStatus are caught too) plus notificationSummaryQueue.
- Transient two-save loading (diff_against_path / diff_paths): the second save's tree is dropped after diffing, so two full saves are never resident.
- Pure view filters (view_filtered): positive group selection + case- insensitive search over object metadata and field path/before/after values.

Compare Saves window (src/gui.rs):
- Compare... menu button (enabled when a save is loaded) picks a second save and caches the full diff; filter changes never re-read the files.
- Left filter rail (noise preset, search, show-all / ignore-all group selection) and right results rail (colored +/-/~ summary, monospace aligned object/field rows, internal scroll, freely resizable window).

Tests: lib unit tests, path tests, and real-save diff self-tests.

Addresses #12 