### PR TITLE
ci: guard release tag against Cargo.toml version (+ bump to 2.1.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,34 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  verify-version:
+    name: Verify tag matches Cargo.toml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare tag against Cargo.toml version
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Tag looks like "refs/tags/v2.1.1"; strip the prefix and leading "v".
+          tag="${GITHUB_REF#refs/tags/}"
+          tag_version="${tag#v}"
+
+          # Pull the [package] version out of Cargo.toml (first `version = "..."`).
+          cargo_version=$(grep -m1 '^version = ' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+
+          echo "Tag version:        ${tag_version}"
+          echo "Cargo.toml version: ${cargo_version}"
+
+          if [[ "${tag_version}" != "${cargo_version}" ]]; then
+            echo "::error::Release tag v${tag_version} does not match Cargo.toml version ${cargo_version}. Bump Cargo.toml (and Cargo.lock) before tagging."
+            exit 1
+          fi
+          echo "OK: tag and Cargo.toml agree on ${cargo_version}"
+
   build:
+    needs: [verify-version]
     uses: ./.github/workflows/build.yml
 
   publish:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tise"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "eframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/staehle/tise"
 repository = "https://github.com/staehle/tise"
 license-file = "LICENSE"
 categories = ["games"]
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
## What

Fixes the version-drift problem behind the v2.1.1 release.

**Root cause:** `release.yml` triggers on tag push and builds whatever commit the tag points at. v2.1.1 was tagged from the webui on a commit whose `Cargo.toml` still said `2.1.0`, so the published binary reports `2.1.0` from `--version` and the About dialog. The draft-release safeguard caught bad *binaries*, not a wrong *version string*.

## Changes

1. **New `verify-version` job in `release.yml`** that gates the build. It strips the `v` from the pushed tag and compares against the `[package]` version in `Cargo.toml`. Mismatch = the release fails *before* building, with a clear error telling you to bump Cargo.toml. A desynced release becomes impossible to publish.
2. **Bump `Cargo.toml` + `Cargo.lock` 2.1.0 -> 2.1.1** to reconcile the current drift with the already-published `v2.1.1` tag.

## Verification (local, full CI gate)

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --locked` 5 passed
- All three workflow files validated as YAML

## Notes

The in-app update checker (item 1 from the ticket) lands as a separate PR. An optional auto-tag-on-merge workflow (fully eliminate manual tagging) can follow if you want it.